### PR TITLE
 chore(bot): Add nix flake and lock rust version with rust-toolchain

### DIFF
--- a/twitch/bot/.envrc
+++ b/twitch/bot/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/twitch/bot/.gitignore
+++ b/twitch/bot/.gitignore
@@ -1,2 +1,6 @@
 \.*\.env
 target
+# direnv metadata
+.direnv
+# nix build symlink
+result

--- a/twitch/bot/flake.lock
+++ b/twitch/bot/flake.lock
@@ -1,0 +1,113 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1728344376,
+        "narHash": "sha256-lxTce2XE6mfJH8Zk6yBbqsbu9/jpwdymbSH5cCbiVOA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fd86b78f5f35f712c72147427b1eb81a9bd55d0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1728542061,
+        "narHash": "sha256-2YAnVU67qimQGO71rCBWcv7RrRK5gYgysXe3NVomuwQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b135535125e24270dddddc8cfab455533492e4ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728505432,
+        "narHash": "sha256-QFPMazeiGLo7AGy4RREmTgko0Quch/toMVKhGUjDEeo=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "0fb804acb375b02a3beeaceeb75b71969ef37b15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/twitch/bot/flake.nix
+++ b/twitch/bot/flake.nix
@@ -1,0 +1,65 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane.url = "github:ipetkov/crane";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    crane,
+    flake-parts,
+    fenix,
+    ...
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux"];
+
+      perSystem = {system, ...}: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [fenix.overlays.default];
+        };
+        lib = pkgs.lib;
+        craneLib = (crane.mkLib pkgs).overrideToolchain (fenix.packages.${system}.fromToolchainFile {
+          dir = ./.;
+          sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+        });
+
+        bot-crate = craneLib.buildPackage {
+          src = lib.cleanSourceWith {
+            src = ./.;
+            filter = path: type: (lib.strings.hasSuffix ".md" path) || (craneLib.filterCargoSources path type);
+            name = "source";
+          };
+
+          buildInputs =
+            [
+              pkgs.openssl
+              pkgs.pkg-config
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+            ];
+        };
+      in {
+        formatter = pkgs.alejandra;
+        packages.default = bot-crate;
+
+        devShells.default = craneLib.devShell {
+          inputsFrom = [bot-crate];
+
+          packages = [
+            pkgs.rust-analyzer-nightly
+          ];
+        };
+      };
+    };
+}

--- a/twitch/bot/rust-toolchain.toml
+++ b/twitch/bot/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.81.0"


### PR DESCRIPTION
Locking to latest stable Rust 1.81 for now, better for reproducibility. Example, this project uses `std::fs::exists` which was added in 1.81 which a lot of people might not have updated to yet. Nix flake is standard, alejandra for `nix fmt`, allows for `nix build` and a `nix develop` shell with rust-analyzer inside of it.