### PR TITLE
bot: Panic handling for commands

### DIFF
--- a/twitch/bot/.envrc
+++ b/twitch/bot/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/twitch/bot/.gitignore
+++ b/twitch/bot/.gitignore
@@ -1,2 +1,6 @@
 \.*\.env
 target
+# direnv metadata
+.direnv
+# nix build symlink
+result

--- a/twitch/bot/flake.lock
+++ b/twitch/bot/flake.lock
@@ -1,0 +1,113 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1728344376,
+        "narHash": "sha256-lxTce2XE6mfJH8Zk6yBbqsbu9/jpwdymbSH5cCbiVOA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "fd86b78f5f35f712c72147427b1eb81a9bd55d0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1728542061,
+        "narHash": "sha256-2YAnVU67qimQGO71rCBWcv7RrRK5gYgysXe3NVomuwQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b135535125e24270dddddc8cfab455533492e4ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1728505432,
+        "narHash": "sha256-QFPMazeiGLo7AGy4RREmTgko0Quch/toMVKhGUjDEeo=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "0fb804acb375b02a3beeaceeb75b71969ef37b15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/twitch/bot/flake.nix
+++ b/twitch/bot/flake.nix
@@ -1,0 +1,65 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane.url = "github:ipetkov/crane";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    crane,
+    flake-parts,
+    fenix,
+    ...
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux"];
+
+      perSystem = {system, ...}: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [fenix.overlays.default];
+        };
+        lib = pkgs.lib;
+        craneLib = (crane.mkLib pkgs).overrideToolchain (fenix.packages.${system}.fromToolchainFile {
+          dir = ./.;
+          sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+        });
+
+        bot-crate = craneLib.buildPackage {
+          src = lib.cleanSourceWith {
+            src = ./.;
+            filter = path: type: (lib.strings.hasSuffix ".md" path) || (craneLib.filterCargoSources path type);
+            name = "source";
+          };
+
+          buildInputs =
+            [
+              pkgs.openssl
+              pkgs.pkg-config
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+            ];
+        };
+      in {
+        formatter = pkgs.alejandra;
+        packages.default = bot-crate;
+
+        devShells.default = craneLib.devShell {
+          inputsFrom = [bot-crate];
+
+          packages = [
+            pkgs.rust-analyzer-nightly
+          ];
+        };
+      };
+    };
+}

--- a/twitch/bot/rust-toolchain.toml
+++ b/twitch/bot/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.81.0"

--- a/twitch/bot/src/command.rs
+++ b/twitch/bot/src/command.rs
@@ -38,16 +38,6 @@ impl Command {
         self.inner.borrow_mut()
     }
 
-    // pub fn borrow(&self) -> &dyn ChatCommand {
-    //     // SAFETY: Single-threaded unique access
-    //     unsafe { &*self.inner.as_ref() }
-    // }
-
-    // pub fn borrow_mut(&self) -> &mut dyn ChatCommand {
-    //     // SAFETY: Single-threaded unique access
-    //     unsafe { &mut *self.inner.as_ptr() }
-    // }
-
     /// Parses the message to check if it's a command
     pub fn parse(message: &str) -> CommandParseResult {
         let trimmed_message = message.trim();
@@ -216,8 +206,6 @@ pub fn handle_command_if_applicable(
         );
         return;
     };
-
-    // let mut cmd = cmd_cell.borrow_mut();
 
     // Check if the command is under cooldown
     if let Some(duration) =

--- a/twitch/bot/src/commands/ban.rs
+++ b/twitch/bot/src/commands/ban.rs
@@ -25,7 +25,7 @@ impl ChatCommand for MostlyBan {
 
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let arg: Vec<_> = ctx.message.text.split_whitespace().skip(1).collect();

--- a/twitch/bot/src/commands/bot_time.rs
+++ b/twitch/bot/src/commands/bot_time.rs
@@ -10,18 +10,22 @@ use super::ChatCommand;
 use std::time::SystemTime;
 
 pub struct BotTime {
-    start_time: SystemTime
+    start_time: SystemTime,
 }
 
 impl ChatCommand for BotTime {
     fn new() -> Self {
         Self {
-            start_time: SystemTime::now()
+            start_time: SystemTime::now(),
         }
     }
 
     fn names() -> Vec<String> {
-        vec!["bottime".to_string(), "bot_time".to_string(), "bot-time".to_string()]
+        vec![
+            "bottime".to_string(),
+            "bot_time".to_string(),
+            "bot-time".to_string(),
+        ]
     }
 
     fn help(&self) -> String {
@@ -31,7 +35,7 @@ impl ChatCommand for BotTime {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let now = SystemTime::now();
@@ -39,18 +43,17 @@ impl ChatCommand for BotTime {
         let minutes = seconds / 60;
         let hours = minutes / 60;
 
-        let msg =
-            if minutes == 0 {
-                format!("Bot has been running for {seconds} seconds.")
-            } else if hours == 0 {
-                format!("Bot has been running for {minutes} minutes.")
-            } else {
-                format!("Bot has been running for {hours} hours.")
-            };
+        let msg = if minutes == 0 {
+            format!("Bot has been running for {seconds} seconds.")
+        } else if hours == 0 {
+            format!("Bot has been running for {minutes} minutes.")
+        } else {
+            format!("Bot has been running for {hours} hours.")
+        };
 
         match api.send_chat_message_with_reply(&msg, Some(&ctx.message_id)) {
             Ok(_) => Ok(()),
-            Err(e) => Err(anyhow!("{:?}", e))
+            Err(e) => Err(anyhow!("{:?}", e)),
         }
     }
 }

--- a/twitch/bot/src/commands/commands.rs
+++ b/twitch/bot/src/commands/commands.rs
@@ -27,7 +27,7 @@ impl ChatCommand for MostlyCommands {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         match api.send_chat_message_with_reply(

--- a/twitch/bot/src/commands/count.rs
+++ b/twitch/bot/src/commands/count.rs
@@ -26,11 +26,14 @@ impl ChatCommand for Count {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let Self(count) = self;
-        if api.send_chat_message(format!("current count: {count}")).is_ok() {
+        if api
+            .send_chat_message(format!("current count: {count}"))
+            .is_ok()
+        {
             *self = Self(*count + 1);
         }
         Ok(())

--- a/twitch/bot/src/commands/discord.rs
+++ b/twitch/bot/src/commands/discord.rs
@@ -22,7 +22,7 @@ impl ChatCommand for MostlyDiscord {
 
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let _ = api.send_chat_message_with_reply(

--- a/twitch/bot/src/commands/git.rs
+++ b/twitch/bot/src/commands/git.rs
@@ -22,7 +22,7 @@ impl ChatCommand for MostlyGit {
 
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let _ = api.send_chat_message_with_reply(

--- a/twitch/bot/src/commands/help.rs
+++ b/twitch/bot/src/commands/help.rs
@@ -37,7 +37,7 @@ impl ChatCommand for MostlyHelp {
     }
 
     #[instrument(skip(self, api, ctx))]
-    fn handle(&mut self, api: &mut TwitchApiWrapper, ctx: &MessageData) -> Result<()> {
+    fn handle(&mut self, api: &TwitchApiWrapper, ctx: &MessageData) -> Result<()> {
         let mut args = ctx.message.text.split_whitespace();
         let _ = args.next();
 

--- a/twitch/bot/src/commands/kofi.rs
+++ b/twitch/bot/src/commands/kofi.rs
@@ -26,7 +26,7 @@ impl ChatCommand for MostlyKofi {
 
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let _ = api.send_chat_message_with_reply(

--- a/twitch/bot/src/commands/lurk.rs
+++ b/twitch/bot/src/commands/lurk.rs
@@ -64,7 +64,7 @@ impl ChatCommand for Lurk {
 
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         // split the words in the messages

--- a/twitch/bot/src/commands/mod.rs
+++ b/twitch/bot/src/commands/mod.rs
@@ -55,7 +55,7 @@ pub trait ChatCommand: 'static {
         Duration::from_millis(DEFAULT_CMD_COOLDOWN_MS)
     }
 
-    fn handle(&mut self, api: &mut TwitchApiWrapper, ctx: &MessageData) -> Result<()>;
+    fn handle(&mut self, api: &TwitchApiWrapper, ctx: &MessageData) -> Result<()>;
 
     fn help(&self) -> String;
 }

--- a/twitch/bot/src/commands/mostlybot.rs
+++ b/twitch/bot/src/commands/mostlybot.rs
@@ -27,7 +27,7 @@ impl ChatCommand for MostlyBot {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         match api.send_chat_message_with_reply(

--- a/twitch/bot/src/commands/mostlypasta.rs
+++ b/twitch/bot/src/commands/mostlypasta.rs
@@ -24,7 +24,7 @@ impl ChatCommand for MostlyPasta {
         vec!["mostlypasta".to_owned()]
     }
 
-    fn handle(&mut self, api: &mut TwitchApiWrapper, ctx: &MessageData) -> Result<()> {
+    fn handle(&mut self, api: &TwitchApiWrapper, ctx: &MessageData) -> Result<()> {
         let mut args = ctx.message.text.split_whitespace();
         let _ = args.next();
         let gnu = args.next().ok_or(anyhow!("not enough arguments"))?;

--- a/twitch/bot/src/commands/ping.rs
+++ b/twitch/bot/src/commands/ping.rs
@@ -77,7 +77,7 @@ impl ChatCommand for MostlyPing {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         match api.send_chat_message_with_reply("pong", Some(&ctx.message_id)) {

--- a/twitch/bot/src/commands/pong.rs
+++ b/twitch/bot/src/commands/pong.rs
@@ -27,7 +27,7 @@ impl ChatCommand for MostlyPong {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         match api.send_chat_message_with_reply("FeelsWeirdMan", Some(&ctx.message_id)) {
@@ -50,12 +50,12 @@ mod test {
 
     #[test]
     fn handle() {
-        let mut api = TwitchApiWrapper::Test(MockTwitchEventSubApi::init_twitch_api());
+        let api = TwitchApiWrapper::Test(MockTwitchEventSubApi::init_twitch_api());
         let mut cmd = MostlyPong::new();
 
         let test_msg = r###"{"broadcaster_user_id":"938429017","broadcaster_user_name":"mostlymaxi","broadcaster_user_login":"mostlymaxi","chatter_user_id":"938429017","chatter_user_name":"mostlymaxi","chatter_user_login":"mostlymaxi","message_id":"3104f083-2bdb-4d6a-bb5d-30b407876ea4","message":{"text":"!pong","fragments":[{"type":"text","text":"!pong","cheermote":null,"emote":null,"mention":null}]},"color":"#FF0000","badges":[{"set_id":"broadcaster","id":"1","info":""},{"set_id":"subscriber","id":"0","info":"3"}],"message_type":"text","cheer":null,"reply":null,"channel_points_custom_reward_id":null,"channel_points_animation_id":null}"###;
 
         let ctx = serde_json::from_str(test_msg).unwrap();
-        cmd.handle(&mut api, &ctx).unwrap();
+        cmd.handle(&api, &ctx).unwrap();
     }
 }

--- a/twitch/bot/src/commands/progress.rs
+++ b/twitch/bot/src/commands/progress.rs
@@ -24,7 +24,7 @@ impl ChatCommand for Progress {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let progress = thread_rng().gen_range(0.0..100.0);

--- a/twitch/bot/src/commands/rewrite.rs
+++ b/twitch/bot/src/commands/rewrite.rs
@@ -6,7 +6,7 @@
 
 use super::ChatCommand;
 use anyhow::anyhow;
-use tracing::{error, debug};
+use tracing::{debug, error};
 
 pub struct MostlyRewrite {}
 
@@ -23,7 +23,11 @@ impl ChatCommand for MostlyRewrite {
         "usage: !rewrite <arguments>".to_string()
     }
 
-    fn handle(&mut self, api: &mut super::TwitchApiWrapper, ctx: &twitcheventsub::MessageData) -> anyhow::Result<()> {
+    fn handle(
+        &mut self,
+        api: &super::TwitchApiWrapper,
+        ctx: &twitcheventsub::MessageData,
+    ) -> anyhow::Result<()> {
         let arg: Vec<_> = ctx.message.text.split_whitespace().skip(1).collect();
         let arg: String = arg.join(" ");
 

--- a/twitch/bot/src/commands/template.rs
+++ b/twitch/bot/src/commands/template.rs
@@ -32,7 +32,7 @@ impl ChatCommand for CommandStruct {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
     }

--- a/twitch/bot/src/commands/tictactoe.rs
+++ b/twitch/bot/src/commands/tictactoe.rs
@@ -1,7 +1,7 @@
 //! Play Tic Tac Toe with a computer because you don't have any REAL friends!
 //!
 //! usage (!tictactoe/!ttt) (reset/1..=9)
-//! 
+//!
 //! author: lunispang
 
 use std::collections::HashMap;
@@ -211,7 +211,7 @@ impl ChatCommand for TicTacToe {
     }
     fn handle(
         &mut self,
-        api: &mut crate::api::TwitchApiWrapper,
+        api: &crate::api::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let arg = ctx.message.text.split_whitespace().nth(1);

--- a/twitch/bot/src/commands/uwu.rs
+++ b/twitch/bot/src/commands/uwu.rs
@@ -240,7 +240,7 @@ impl ChatCommand for MostlyUwU {
     #[instrument(skip(self, api))]
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         // Collect Args -> Load kaomoji -> Validate permissions -> Execute command

--- a/twitch/bot/src/commands/vods.rs
+++ b/twitch/bot/src/commands/vods.rs
@@ -22,7 +22,7 @@ impl ChatCommand for MostlyVods {
 
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let _ = api.send_chat_message_with_reply(

--- a/twitch/bot/src/commands/youtube.rs
+++ b/twitch/bot/src/commands/youtube.rs
@@ -22,7 +22,7 @@ impl ChatCommand for MostlyYoutube {
 
     fn handle(
         &mut self,
-        api: &mut super::TwitchApiWrapper,
+        api: &super::TwitchApiWrapper,
         ctx: &twitcheventsub::MessageData,
     ) -> anyhow::Result<()> {
         let _ = api.send_chat_message_with_reply(

--- a/twitch/bot/src/main.rs
+++ b/twitch/bot/src/main.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+use std::cell::RefCell;
 use std::time::Duration;
 
 use mostlybot::*;
@@ -72,7 +73,7 @@ async fn cancel_on_signal(token: CancellationToken) {
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let mut api = TwitchApiWrapper::Live(init_twitch_api());
+    let mut api = TwitchApiWrapper::Live(RefCell::new(init_twitch_api()));
     let mut consumer = init_franz_consumer("chat").await;
 
     let cancel_token = CancellationToken::new();

--- a/twitch/bot/src/main.rs
+++ b/twitch/bot/src/main.rs
@@ -73,7 +73,7 @@ async fn cancel_on_signal(token: CancellationToken) {
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let mut api = TwitchApiWrapper::Live(RefCell::new(init_twitch_api()));
+    let api = TwitchApiWrapper::Live(RefCell::new(init_twitch_api()));
     let mut consumer = init_franz_consumer("chat").await;
 
     let cancel_token = CancellationToken::new();
@@ -96,6 +96,6 @@ async fn main() {
             continue;
         };
 
-        handle_command_if_applicable(&chat_msg, &mut api, &mut commands, &bot_id, &mut spam_check);
+        handle_command_if_applicable(&chat_msg, &api, &mut commands, &bot_id, &mut spam_check);
     }
 }


### PR DESCRIPTION
Depends on #44 (I'll rebase after that gets squash merged here)

**This is untested by me, puhLEASE test this one first maxi**

This pr does as title says, uses `std::panic::catch_unwind` when running commands since one panic = bot dead.

Due to the `UnwindSafe` and `RefUnwindSafe` trait not being implemented on `&RefCell<T>` there are two routes I saw:

- Making `Command::inner` Rc<Mutex<T>>` as `Mutex<T>` satisfies those traits.
- Self implementing those traits

I went the second route since there's no multi-threading (past signal handling) and I don't /believe/ this would cause any issues to my knowledge. Also had to change the `TwitchApiWrapper` signatures to be `&self` instead of `&mut self` due to the `UnwindSafe` set of traits not being implemented on `&mut T`, now it just uses a RefCell for mutability of the wrapped Twitch API struct.