### PR TITLE
Lurk updated with !lurkwith, !lurker & !lurkers

### DIFF
--- a/twitch/bot/src/commands/lurk.rs
+++ b/twitch/bot/src/commands/lurk.rs
@@ -1,41 +1,47 @@
 //! command that lets mostlymaxi know that you are lurking and will not be paying attention to the
 //! stream during the term of your lurk
 //!
-//! usage: ```!lurk``` or ```!unlurk```
+//! usage: ```!lurk``` or ```!lurkwith <status>``` or ```!unlurk``` or ```!lurker [@username]``` or
+//! ```!lurkers```
 //!
 //! author: bhavyakukkar
 
 use anyhow::anyhow;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use twitcheventsub::EventSubError;
 
 use super::ChatCommand;
 
-const LURK_SUCCESSFUL: &str = "have a nice lurk!";
-const LURK_FAILED: &str = "you are already lurking silly! to unlurk do !unlurk";
-const UNLURK_SUCCESSFUL: &str = "welcome back! hope you were productive during your lurk!";
-const UNLURK_FAILED: &str = "you weren't lurking but welcome back anyway!";
+mod replies {
+    pub const LURK_SUCCESSFUL: &str = "have a nice lurk!";
+
+    // make sure to keep the @ which will get replaced with chatter's name
+    pub const LURK_FAILED: &str =
+        "you are already lurking silly! to unlurk do `!unlurk` or view your lurk-status with \
+        `!lurker @`";
+
+    pub const LURK_STATUS_UPDATED: &str = "lurk status successfully updated!";
+
+    // make sure to keep the % which will get replaced with what was chatter's lurking status
+    pub const UNLURK_SUCCESSFUL: &str = "welcome back! hope you were productive %";
+
+    pub const UNLURK_FAILED: &str = "you weren't lurking but welcome back anyway!";
+
+    // make sure to keep the @ which will get replaced with chatter's name and % which will get
+    // replaced with chatter's lurking status
+    pub const LURKED_SUCCESSFUL: &str = "@ is lurking %";
+
+    pub const LURKER_FAILED: &str = "you're not lurking";
+}
+
+type Username = String;
+type LurkStatus = Option<String>;
 
 /// A struct holding the users that are currently lurking
 pub struct Lurk {
-    /// A hash-set of the ids of the users that are currently lurking
-    pub users_lurking: HashSet<String>,
-}
-
-impl Lurk {
-    /// Create the Lurk command starting with no users currently lurking
-    pub fn new() -> Self {
-        Lurk {
-            users_lurking: HashSet::new(),
-        }
-    }
-}
-
-// added Default impl so clippy will stop complaining
-impl Default for Lurk {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// A hash-map of the usernames of the users that are currently lurking mapped to their
+    /// lurk-status
+    pub users_lurking: HashMap<Username, LurkStatus>,
 }
 
 // what to do when an api reply succeeds
@@ -51,15 +57,24 @@ fn reply_err(e: EventSubError) -> anyhow::Error {
 
 impl ChatCommand for Lurk {
     fn new() -> Self {
-        Lurk::new()
+        Lurk {
+            users_lurking: HashMap::new(),
+        }
     }
 
     fn names() -> Vec<String> {
-        vec!["lurk".to_string(), "unlurk".to_string()]
+        vec![
+            "lurk".to_string(),
+            "lurkwith".to_string(),
+            "unlurk".to_string(),
+            "lurker".to_string(),
+            "lurkers".to_string(),
+        ]
     }
 
     fn help(&self) -> String {
-        "usage: !lurk or !unlurk".to_string()
+        "usage: `!lurk` or `!lurkwith <status>` or `!unlurk` or `!lurker [@username]` or `!lurkers`"
+            .to_string()
     }
 
     fn handle(
@@ -77,34 +92,124 @@ impl ChatCommand for Lurk {
         // match the command: lurk or unlurk
         match command_invoked {
             "!lurk" => {
-                if self.users_lurking.insert(ctx.chatter.id.clone()) {
-                    // user has called !lurk while not previously lurking and will now start lurking
-                    api.send_chat_message_with_reply(LURK_SUCCESSFUL, Some(&ctx.message_id))
+                match self.users_lurking.insert(ctx.chatter.name.clone(), None) {
+                    // called !lurk while not previously lurking and will now start lurking
+                    None => api
+                        .send_chat_message_with_reply(
+                            replies::LURK_SUCCESSFUL,
+                            Some(&ctx.message_id),
+                        )
                         .map(reply_ok)
-                        .map_err(reply_err)
-                } else {
-                    // user called !lurk while already lurking and will just continue lurking
-                    api.send_chat_message_with_reply(LURK_FAILED, Some(&ctx.message_id))
+                        .map_err(reply_err),
+                    // called !lurk while already lurking with or without a status, will continue
+                    // lurking
+                    Some(_) => api
+                        .send_chat_message_with_reply(
+                            &replies::LURK_FAILED.replace("@", &ctx.chatter.name),
+                            Some(&ctx.message_id),
+                        )
                         .map(reply_ok)
-                        .map_err(reply_err)
+                        .map_err(reply_err),
+                }
+            }
+            "!lurkwith" => {
+                // join the rest of the words in the message into the lurk-status
+                let status: String = args.fold(String::new(), |a, b| a + " " + b);
+
+                match self
+                    .users_lurking
+                    .insert(ctx.chatter.name.clone(), Some(status))
+                {
+                    // called !lurkwith while not previously lurking and will now start lurking
+                    None => api
+                        .send_chat_message_with_reply(
+                            replies::LURK_SUCCESSFUL,
+                            Some(&ctx.message_id),
+                        )
+                        .map(reply_ok)
+                        .map_err(reply_err),
+                    // called !lurkwith while already lurking with or without a status, will
+                    // continue lurking but with an updated status
+                    Some(_) => api
+                        .send_chat_message_with_reply(
+                            replies::LURK_STATUS_UPDATED,
+                            Some(&ctx.message_id),
+                        )
+                        .map(reply_ok)
+                        .map_err(reply_err),
                 }
             }
             "!unlurk" => {
-                if self.users_lurking.remove(&ctx.chatter.id) {
-                    // user has called !unlurk while previously lurking and will now stop lurking
-                    api.send_chat_message_with_reply(UNLURK_SUCCESSFUL, Some(&ctx.message_id))
+                match self.users_lurking.remove(&ctx.chatter.name) {
+                    // called !unlurk while previously lurking and will now stop lurking
+                    Some(previous_status) => api
+                        .send_chat_message_with_reply(
+                            &replies::UNLURK_SUCCESSFUL.replace(
+                                "%",
+                                &previous_status.unwrap_or("during your lurk!".to_string()),
+                            ),
+                            Some(&ctx.message_id),
+                        )
                         .map(reply_ok)
-                        .map_err(reply_err)
-                } else {
-                    // user has called !unlurk while not previously lurking and will continue not
-                    // lurking
-                    api.send_chat_message_with_reply(UNLURK_FAILED, Some(&ctx.message_id))
+                        .map_err(reply_err),
+                    // called !unlurk while not previously lurking and will continue not lurking
+                    None => api
+                        .send_chat_message_with_reply(replies::UNLURK_FAILED, Some(&ctx.message_id))
                         .map(reply_ok)
-                        .map_err(reply_err)
+                        .map_err(reply_err),
                 }
             }
+            "!lurker" => {
+                // join the rest of the words in the message into the username
+                let mut username: String = args.fold(String::new(), |a, b| a + " " + b);
+
+                // if no username provided, assume chatter's name as username
+                if username.is_empty() {
+                    username = ctx.chatter.name.clone();
+                }
+
+                // if username starts with @, remove it
+                let mut chars = username.chars();
+                if chars.next().ok_or(anyhow!("chatter.name received empty"))? == '@' {
+                    username = chars.collect();
+                }
+
+                match self.users_lurking.get(&username) {
+                    // called !lurker for username that is lurking with or without a status
+                    Some(status) => api
+                        .send_chat_message(
+                            replies::LURKED_SUCCESSFUL
+                                .replace("@", &("@".to_string() + &username))
+                                .replace(
+                                    "%",
+                                    &status.clone().unwrap_or("with no status".to_string()),
+                                ),
+                        )
+                        .map(reply_ok)
+                        .map_err(reply_err),
+                    // called !lurker for username that is not currently lurking
+                    None => api
+                        .send_chat_message(replies::LURKER_FAILED)
+                        .map(reply_ok)
+                        .map_err(reply_err),
+                }
+            }
+            "!lurkers" => api
+                .send_chat_message(
+                    "Lurkers: ".to_string()
+                        + &self
+                            .users_lurking
+                            .keys()
+                            .map(|username| "@".to_string() + username)
+                            .reduce(|a, b| a + ", " + &b)
+                            .unwrap_or("<none>".to_string()),
+                )
+                .map(reply_ok)
+                .map_err(reply_err),
+
             _ => Err(anyhow!(
-                "invoked lurk command without first word being neither lurk nor unlurk"
+                "invoked lurk command without first word being any of the commands {:?}",
+                Self::names()
             )),
         }
     }


### PR DESCRIPTION
- added command !lurkwith that lurks with a custom status message
- added command !lurker that takes an optional username and returns their lurk status if they are lurking
- added command !lurkers that lists all currently lurking users
- removed useless Default impl of struct Lurk
- added more replies, some templated, for all new commands
- removed native impl fn new for minimum confusion with trait fn new
- updated LURK_FAILED to also inform user how to lurk with a new status
- updated UNLURK_SUCCESSFUL to include what was user's lurk status
- updated error message on unmatched command to print all command names automatically